### PR TITLE
Changes in the HeartBeat Response Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ if (hbtype == TLS1_HB_REQUEST)
     // this function will copy the 3+payload+padding bytes
     // from the buffer and put them into the heartbeat response
     // packet to send back to the request client side.
-    OPENSSL_free(buffer);
     r = ssl3_write_bytes(s, TLS1_RT_HEARTBEAT, buffer, 3 + payload + padding);
+    OPENSSL_free(buffer);
 }
 ```
 


### PR DESCRIPTION
The call to `OPENSSL_free(buffer);` should come after `r = ssl3_write_bytes(s, TLS1_RT_HEARTBEAT, buffer, 3 + payload + padding);` else that opens room for another vulnerability. ;)